### PR TITLE
Add flowcharts to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,8 @@ Execute o instalador a partir da pasta `kexts`:
 ```
 
 Consulte a documentação no idioma desejado para detalhes adicionais.
+
+## Fluxograma / Flowchart
+
+![Fluxograma em Português](docs/pt_BR/fluxograma_instalacao_vertical.png)
+![Flowchart in English](docs/en/fluxograma_installation_vertical.png)


### PR DESCRIPTION
## Summary
- include installation flowcharts for both languages in the main README

## Testing
- `bash -n kexts/instalar_auxiliares_autoelevado.command`
- `bash -n kexts/hackintosh_script`


------
https://chatgpt.com/codex/tasks/task_e_6865351561748328bd4c7eec077022b7

## Summary by Sourcery

Add installation flowcharts to the main README in both Portuguese and English

Documentation:
- Include Portuguese installation flowchart image in README
- Include English installation flowchart image in README