### PR TITLE
Fix missing flowchart in English docs

### DIFF
--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -48,3 +48,6 @@ Enter your password when prompted and reboot your system.
 ├── AirPortUtility.kext
 └── BluetoothFileExchange.kext
 ```
+## Installation Flowchart
+
+![Installation flowchart](fluxograma_installation_vertical.png)


### PR DESCRIPTION
## Summary
- add an Installation Flowchart section to the English README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686537509ac48328bfcfeae8a90939be

## Summary by Sourcery

Documentation:
- Add "Installation Flowchart" heading to end of docs/en/README.md